### PR TITLE
Update to tokio-tungstenite v0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ httparse = "1.3.4"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio-tungstenite = "0.16"
+tokio-tungstenite = "0.20"
 tokio = { version = "1.15", default-features = false, features = ["net"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,18 +51,21 @@ pub enum Error {
     /// Protocol violation.
     #[error("WebSocket protocol error: {0}")]
     Protocol(#[from] ProtocolError),
-    /// Message send queue full.
-    #[error("Send queue is full")]
-    SendQueueFull(crate::Message),
+    /// Message write buffer is full.
+    #[error("Write buffer is full")]
+    WriteBufferFull(crate::Message),
     /// UTF coding error.
     #[error("UTF-8 encoding error")]
     Utf8,
+    /// Attack attempt detected.
+    #[error("Attack attempt detected")]
+    AttackAttempt,
     /// Invalid URL.
     #[error("URL error: {0}")]
     Url(#[from] UrlError),
     /// HTTP error.
     #[error("HTTP error: {}", .0.status())]
-    Http(Response<Option<String>>),
+    Http(Response<Option<Vec<u8>>>),
     /// HTTP format error.
     #[error("HTTP format error: {0}")]
     HttpFormat(#[from] http::Error),


### PR DESCRIPTION
### Problem

The `tokio-tungstenite` dependency is out of date. I want to integrate this crate with [`ezsockets`](https://github.com/gbaranski/ezsockets) so we can have WASM clients, but we need `tokio-tungstenite` v0.20 in order to use `axum_tungstenite`.

### Solution

Update the dependency.
