### PR TITLE
fix: allow TLS features to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-tungstenite-wasm"
-version = "0.2.0"
+version = "0.2.1"
 description = "A wrapper around websys and tokio-tungstenite that makes it easy to use websockets cross-platform."
 repository = "https://github.com/TannerRogalsky/tokio-tungstenite-wasm"
 homepage = "https://github.com/TannerRogalsky/tokio-tungstenite-wasm"
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-native-tls = ["tokio-tungstenite/native-tls"]
+native-tls = ["tokio-tungstenite/native-tls", "dep:native-tls"]
 native-tls-vendored = ["native-tls", "tokio-tungstenite/native-tls-vendored"]
 rustls-tls-native-roots = [
     "__rustls-tls",
@@ -19,7 +19,7 @@ rustls-tls-webpki-roots = [
     "__rustls-tls",
     "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
-__rustls-tls = []
+__rustls-tls = ["dep:rustls"]
 
 [dependencies]
 thiserror = "1"
@@ -30,9 +30,13 @@ futures-util = { version = "0.3", default-features = false, features = [
     "std",
 ] }
 
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio-tungstenite = "0.20"
 tokio = { version = "1", default-features = false, features = ["net"] }
+native-tls = { version = "0.2.11", default-features = false, optional = true }
+rustls = { version = "0.21.6", default-features = false, optional = true }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -261,19 +261,15 @@ pub enum UrlError {
 #[non_exhaustive]
 pub enum TlsError {
     /// Native TLS error.
-    #[cfg(feature = "native-tls")]
+    #[cfg(all(feature = "native-tls", not(target_arch = "wasm32")))]
     #[error("native-tls error: {0}")]
-    Native(#[from] native_tls_crate::Error),
+    Native(#[from] native_tls::Error),
     /// Rustls error.
-    #[cfg(feature = "__rustls-tls")]
+    #[cfg(all(feature = "__rustls-tls", not(target_arch = "wasm32")))]
     #[error("rustls error: {0}")]
     Rustls(#[from] rustls::Error),
-    /// Webpki error.
-    #[cfg(feature = "__rustls-tls")]
-    #[error("webpki error: {0}")]
-    Webpki(#[from] webpki::Error),
     /// DNS name resolution error.
-    #[cfg(feature = "__rustls-tls")]
+    #[cfg(all(feature = "__rustls-tls", not(target_arch = "wasm32")))]
     #[error("Invalid DNS name")]
     InvalidDnsName,
     /// Unknown

--- a/src/native.rs
+++ b/src/native.rs
@@ -247,13 +247,11 @@ impl From<ProtocolError> for crate::error::ProtocolError {
 impl From<TlsError> for crate::error::TlsError {
     fn from(err: TlsError) -> Self {
         match err {
-            #[cfg(feature = "native-tls")]
+            #[cfg(all(feature = "native-tls", not(target_arch = "wasm32")))]
             TlsError::Native(inner) => crate::error::TlsError::Native(inner),
-            #[cfg(feature = "__rustls-tls")]
+            #[cfg(all(feature = "__rustls-tls", not(target_arch = "wasm32")))]
             TlsError::Rustls(inner) => crate::error::TlsError::Rustls(inner),
-            #[cfg(feature = "__rustls-tls")]
-            TlsError::Webpki(inner) => crate::error::TlsError::Webpki(inner),
-            #[cfg(feature = "__rustls-tls")]
+            #[cfg(all(feature = "__rustls-tls", not(target_arch = "wasm32")))]
             TlsError::InvalidDnsName => crate::error::TlsError::InvalidDnsName,
             _ => crate::error::TlsError::Unknown,
         }


### PR DESCRIPTION
rustls has to be explicitly brought in as a dependency in order to refer to it in the TlsError enum. Additionally, webpki was removed as the variant seems unrelated. So, this is _kind of_ a breaking change, though it never compiled (for me anyway) in the first place.

Before cutting a release, maybe updating dependencies (http, rustls, tokio-tungstenite) would be prudent?