### PR TITLE
fix: make error module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod error;
+pub mod error;
 mod message;
 #[cfg(not(target_arch = "wasm32"))]
 mod native;


### PR DESCRIPTION
The `tokio_tungstenite_wasm::error` module is private, so I can’t match on `Error::Protocol(ProtocolError::…)` in user code.
This PR makes it public so that downstream code can pattern-match all possible error types.