### PR TITLE
Allow a custom TLS connector on native

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,4 +75,4 @@ assert-impl = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-rand = "0.8"
+rand = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,14 @@ pub async fn connect_with_protocols<S: AsRef<str>>(
     ws::connect_with_protocols(url.as_ref(), protocols).await
 }
 
+#[cfg(any(feature = "native-tls", feature = "__rustls-tls"))]
+#[cfg(not(target_arch = "wasm32"))]
+pub use ws::connect_custom_tls;
+
+#[cfg(any(feature = "native-tls", feature = "__rustls-tls"))]
+#[cfg(not(target_arch = "wasm32"))]
+pub use ws::Connector;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Based on changes from this fork https://github.com/semio-ai/tokio-tungstenite-wasm